### PR TITLE
Display Footnotes & Integrate CMS

### DIFF
--- a/src/components/FootnoteSlideOver.tsx
+++ b/src/components/FootnoteSlideOver.tsx
@@ -18,8 +18,6 @@ export default function FootnoteSlideOver() {
   const $originalTuk = useStore(originalTuk);
   const $customFootnotes = useStore(customFootnotes);
 
-  console.log("$bhaiVirSinghFootnote", $bhaiVirSinghFootnote);
-  console.log("$customFootnotes", $customFootnotes);
   return (
     <Transition.Root show={$isOpen} as={Fragment}>
       <Dialog

--- a/src/components/HighlightedTuk.svelte
+++ b/src/components/HighlightedTuk.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import {
+    isOpen,
+    originalTuk,
+    bhaiVirSinghFootnote,
+    customFootnotes,
+  } from "../store/tukFootnoteStore";
+
+  import type { Tuk } from "../types/appTypes";
+
+  export let tuk: Tuk;
+  export let pauriNumber: number;
+  export let isLastTuk: boolean;
+
+  function openSidePanel() {
+    isOpen.set(true);
+    bhaiVirSinghFootnote.set(tuk.drVirSinghFootnote);
+    originalTuk.set(tuk.originalContent);
+    customFootnotes.set(tuk.footnote?.customFootnotes);
+  }
+</script>
+
+<button class="leading-8 text-lg cursor-pointer" on:click={openSidePanel}>
+  <span class="bg-gray-200 py-1">
+    {tuk.content}
+    <span>
+      {isLastTuk ? `॥${pauriNumber}॥` : " ।"}
+    </span>
+  </span>
+</button>

--- a/src/components/Pauri.astro
+++ b/src/components/Pauri.astro
@@ -1,0 +1,47 @@
+---
+import HighlightedTuk from "./HighlightedTuk.svelte";
+import { Pauri } from "../types/appTypes";
+
+export interface Props {
+  pauri: Pauri;
+}
+
+const { pauri } = Astro.props;
+---
+
+{
+  pauri.tuks.map((tuk, index) => (
+    <>
+      <div>
+        {tuk.drVirSinghFootnote === null && tuk.footnote === null ? (
+          <div>
+            <p class="leading-8 text-lg">
+              <span>{tuk.content}</span>
+              <span>
+                {index + 1 === pauri.tuks.length ? `॥${pauri.number}॥` : " ।"}
+              </span>
+            </p>
+            <p class="leading-8 text-lg text-amber-800">
+              <span>{tuk.translation?.enTranslation}</span>
+              <span>
+                {index + 1 === pauri.tuks.length
+                  ? ` ||${pauri.number}||`
+                  : " |"}
+              </span>
+            </p>
+          </div>
+        ) : (
+          <HighlightedTuk
+            tuk={tuk}
+            isLastTuk={index + 1 === pauri.tuks.length}
+            pauriNumber={pauri.number}
+            client:load
+          />
+        )}
+        <p class="leading-8 text-lg text-amber-800">
+          {pauri.translation?.enTranslation}
+        </p>
+      </div>
+    </>
+  ))
+}

--- a/src/helpers/contentful.js
+++ b/src/helpers/contentful.js
@@ -1,0 +1,6 @@
+import contentful from "contentful";
+
+export const client = contentful.createClient({
+  space: import.meta.env.CMS_SPACE_ID,
+  accessToken: import.meta.env.CMS_ACCESS_TOKEN,
+});

--- a/src/helpers/fetchFootnoteContent.ts
+++ b/src/helpers/fetchFootnoteContent.ts
@@ -1,0 +1,73 @@
+import { Entry, Asset } from "contentful";
+import { Document } from "@contentful/rich-text-types";
+import { client } from "./contentful.js";
+
+interface FootnoteContentItem {
+  content: Document | null;
+  media: Asset | null;
+}
+
+interface FootnoteContent {
+  vidhiyaSaagar: FootnoteContentItem | null;
+  kamalpreetSingh: FootnoteContentItem | null;
+  manglacharan: FootnoteContentItem | null;
+}
+
+interface FootnoteFields {
+  entryName: string;
+  vidhiyaSaagarContent: Document;
+  vidhiyaSaagarMedia: Asset;
+  kamalpreetSinghContent: Document;
+  kamalpreetSinghMedia: Asset;
+  manglacharanContent: Document;
+}
+
+type FootnoteEntry = Entry<FootnoteFields>;
+
+/**
+ * Fetches and returns a FootnoteContentItem object with content and media if either exists, otherwise returns null.
+ *
+ * @param {Document | null} content - The contentful rich text content of the footnote item.
+ * @param {string | null} mediaId - The contentful Asset ID of the media associated with the footnote item.
+ * @returns {Promise<FootnoteContentItem | null>} A FootnoteContentItem object if either content or media exists, otherwise null.
+ */
+async function getFootnoteContentItem(
+  content: Document,
+  mediaId: string
+): Promise<FootnoteContentItem | null> {
+  const media = mediaId ? await client.getAsset(mediaId) : null;
+
+  if (!content && !media) {
+    return null;
+  }
+
+  return { content: content || null, media };
+}
+
+export async function fetchFootnoteContent(
+  entryId: string
+): Promise<FootnoteContent> {
+  const entry: FootnoteEntry | undefined = await client.getEntry(entryId);
+
+  if (!entry) {
+    console.error(`Failed to fetch entry with id ${entryId}`);
+    return;
+  }
+
+  const footnoteContent: FootnoteContent = {
+    vidhiyaSaagar: await getFootnoteContentItem(
+      entry.fields.vidhiyaSaagarContent,
+      entry.fields.vidhiyaSaagarMedia?.sys.id
+    ),
+    kamalpreetSingh: await getFootnoteContentItem(
+      entry.fields.kamalpreetSinghContent,
+      entry.fields.kamalpreetSinghMedia?.sys.id
+    ),
+    manglacharan: await getFootnoteContentItem(
+      entry.fields.manglacharanContent,
+      null
+    ),
+  };
+
+  return footnoteContent;
+}

--- a/src/pages/chapters/[id].astro
+++ b/src/pages/chapters/[id].astro
@@ -1,5 +1,8 @@
 ---
+import FootnoteSlideOver from "../../components/FootnoteSlideOver";
+import Pauri from "../../components/Pauri.astro";
 import Layout from "../../layouts/Layout.astro";
+import { fetchFootnoteContent } from "../../helpers/fetchFootnoteContent";
 
 export const getStaticPaths = async () => {
   const API_URL = import.meta.env.API_URL;
@@ -33,6 +36,37 @@ const API_URL = import.meta.env.API_URL;
 
 const chapterContentRes = await fetch(`${API_URL}/chapters/${id}/content.json`);
 const { chapter } = await chapterContentRes.json();
+
+/**
+ * Fetch footnotes for each Pauri and Tuk
+ */
+const footnotePromises = [];
+
+console.log("STARTING TO FETCH FOOTNOTES");
+for (const chhand of chapter.chhands) {
+  for (const pauri of chhand.pauris) {
+    if (pauri.footnote?.entryId) {
+      const promise = fetchFootnoteContent(pauri.footnote.entryId).then(
+        (customFootnotes) => {
+          pauri.footnote.customFootnotes = customFootnotes;
+        }
+      );
+      footnotePromises.push(promise);
+    }
+    for (const tuk of pauri.tuks) {
+      if (tuk.footnote?.entryId) {
+        const promise = fetchFootnoteContent(tuk.footnote.entryId).then(
+          (customFootnotes) => {
+            tuk.footnote.customFootnotes = customFootnotes;
+          }
+        );
+        footnotePromises.push(promise);
+      }
+    }
+  }
+}
+
+await Promise.all(footnotePromises);
 ---
 
 <Layout title={`SPG - Chapter ${chapter.number} - ${chapter.title}`}>
@@ -61,28 +95,14 @@ const { chapter } = await chapterContentRes.json();
         return (
           <div class="my-4">
             <h3 class="font-serif text-xl font-semibold">{chhand.name}</h3>
-            {chhand.pauris.map((pauri) => {
-              return (
-                <div class="my-1">
-                  {pauri.tuks.map((tuk, index) => {
-                    return (
-                      <p class="leading-8 text-lg">
-                        {tuk.content}
-                        <span>
-                          {index + 1 === pauri.tuks.length
-                            ? `॥${pauri.number}॥`
-                            : " ।"}
-                        </span>
-                      </p>
-                    );
-                  })}
-                </div>
-              );
-            })}
+            {chhand.pauris.slice(0, 5).map((pauri) => (
+              <Pauri pauri={pauri} />
+            ))}
           </div>
         );
       })
     }
   </div>
-  <!-- The `tuks` -->
+
+  <FootnoteSlideOver client:load />
 </Layout>

--- a/src/pages/chapters/[id].astro
+++ b/src/pages/chapters/[id].astro
@@ -42,7 +42,6 @@ const { chapter } = await chapterContentRes.json();
  */
 const footnotePromises = [];
 
-console.log("STARTING TO FETCH FOOTNOTES");
 for (const chhand of chapter.chhands) {
   for (const pauri of chhand.pauris) {
     if (pauri.footnote?.entryId) {


### PR DESCRIPTION
## Descriptions

<img src="https://user-images.githubusercontent.com/17516559/227405781-a3483ebb-d654-4a9f-973b-6ecee895c1ce.gif" alt="When a line with a footnote is clicked, it loads Kamalpreet's footnotes in a blog format" width="512" />

There is a lot going on in this Pull Request. Allow me to break it down!

### Hiding and Showing the `<FootnoteSlideOver />`. 

* We created a `tukFootnoteStore` that stores information like `isOpen` (should it be open or no) and the footnote contents
* Whenever someone clicks on the `<HighlightedTuk />` component, it emits an `click` event
* That will set the `isOpen` to be `true`. 
* It will also update the footnote contents 

### What is a CMS? 

I realized that it's too much of a pain to do all the Markdown and HTML-ifying in our own database. 

I eventually came across something called Contenful when I was browsing through the Astro docs. This is what we can do in Astro.

#### 1. Define a Content Model 

For us, it's the footnote content. A footnote will have some Rich Text. It might also have an image. So, that's what I defined. I figured that for now, the custom footnotes will be written by the following:

* Vidhiya Saagar group
* Mangalacharan group
* Kamalpreet Singh

So, this is what we have:

<img width="1412" alt="Screen Shot 2023-03-23 at 9 49 33 PM" src="https://user-images.githubusercontent.com/17516559/227404830-5b75bd9c-7e6b-4f73-898a-b1cedbdc814a.png">


#### 2. Create Content

<img width="1425" alt="Screen Shot 2023-03-23 at 9 49 54 PM" src="https://user-images.githubusercontent.com/17516559/227404877-8131c3ea-7956-4039-af14-7437f3da6504.png">

So, you write all the content and stuff here. You can also invite people here to collaborate. 

#### 3. Save the `entryId` in the SPG2 Database and Fetch the Data

<img width="883" alt="Screen Shot 2023-03-23 at 9 50 16 PM" src="https://user-images.githubusercontent.com/17516559/227405011-04be0227-4836-4d87-b19d-69ad02f16790.png">
