### PR TITLE
Upgrade to Node 24 LTS + build pipeline docs + code improvements

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -18,11 +18,16 @@ const { title, includeNav = true } = Astro.props;
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
-    {includeNav && <Nav client:load />}
+    <!-- Apply saved theme before first paint to prevent flash -->
+    <script is:inline>
+      const t = localStorage.getItem('theme');
+      if (t) document.documentElement.setAttribute('data-theme', t);
+    </script>
     <slot name="extra-headers" />
     <ViewTransitions />
   </head>
   <body class="px-4 py-8 sm:px-6 lg:px-8">
+    {includeNav && <Nav client:load />}
     <slot />
   </body>
 </html>


### PR DESCRIPTION
## Summary

- Upgrade to **Node 24 LTS** (Krypton) — adds `.nvmrc` and `engines` field in `package.json`
- Add **Build Pipeline** section to README explaining Astro SSG, Contentful, and env requirements
- Create `.env` template with all required keys documented
- Add typed env vars in `src/env.d.ts` and a `yarn check` script

## Code improvements

- Extract shared `contentfulOptions` into `src/helpers/contentfulRichText.jsx`, resolving the TODO in `BlogPost.jsx` — also adds PDF asset support to blog posts
- Remove debug `console.log` from `FootnoteSlideOver.tsx` and guard against missing avatar
- Move `@astrojs/check` and `typescript` to `devDependencies`

## Bug fixes

- Fix `ReferenceError: React is not defined` at build time — missing `import React` in extracted helper
- Fix flash of unstyled content (FOUC) — `Nav` was incorrectly placed in `<head>` instead of `<body>`, and added an inline script to apply saved theme before first paint

## Blog table styling

- Medium-style tables: rounded card border, muted uppercase headers, subtle row dividers, hover highlight
- Tables bleed wider than the prose column on desktop (≥1024px) for breathing room
- Horizontal scroll on mobile via `.table-wrapper`
- Vertical-align middle on cells

## Test plan

- [ ] `nvm use` → should switch to Node 24
- [ ] `yarn install` → clean
- [ ] `yarn run dev` → dev server starts on `localhost:4321`
- [ ] `/blog` loads and tables render correctly
- [ ] No flash on page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)